### PR TITLE
Use transferList for angular2-web-workers communication.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 *.map
+/.idea/

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ npm i angular2-web-worker
 # API
 ```javascript
 export interface IWebWorkerService {
-    run<T>(workerFunction: (input: any) => T | { data: T, transferObjects: any[] }, data?: any, transferObject?: any[]): Promise<T>;
-    runUrl(url: string, data: any, transferObjects: any[]): Promise<T>;
+    run<T>(workerFunction: (input: any) => T | { data: T, transferList: any[] }, data?: any, transferObject?: any[]): Promise<T>;
+    runUrl(url: string, data: any, transferList: any[]): Promise<T>;
     terminate<T>(promise: Promise<T>): Promise<T>;
     getWorker(promise: Promise<any>): Worker;
 }
@@ -58,8 +58,11 @@ export interface IWebWorkerService {
             }, 10);
             ```
     * `data`: [serializable data](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm)
-    * `transferList`: Optional array of transferObjects to pass ownership of objects between between Web workers and the main thread. 
-    Mainly usable for transfer of big amount of data e.g. via ArrayBuffer. @see [Transferable](https://developer.mozilla.org/en-US/docs/Web/API/Transferable) 
+    * `transferList`: Optional list to pass ownership of objects between web workers and the main thread. 
+    Mainly usable for transfer of big amount of data e.g. via ArrayBuffer. 
+    @see [postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Worker/postMessage) 
+    @see [Transferable](https://developer.mozilla.org/en-US/docs/Web/API/Transferable),
+ 
 * `runUrl`: Basically the same as 
     * `url`:  The url you would use to create a [`Worker`](https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker) instance
     * `data`: Same as the `run` method

--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ npm i angular2-web-worker
 # API
 ```javascript
 export interface IWebWorkerService {
-    run<T>(workerFunction: (any) => T, data?: any): Promise<T>;
-    runUrl(url: string, data?: any): Promise<any>;
+    run<T>(workerFunction: (input: any) => T | { data: T, transferObjects: any[] }, data?: any, transferObject?: any[]): Promise<T>;
+    runUrl(url: string, data: any, transferObjects: any[]): Promise<T>;
     terminate<T>(promise: Promise<T>): Promise<T>;
+    getWorker(promise: Promise<any>): Worker;
 }
+
 ```
 
 * `run`
@@ -56,6 +58,8 @@ export interface IWebWorkerService {
             }, 10);
             ```
     * `data`: [serializable data](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm)
+    * `transferList`: Optional array of transferObjects to pass ownership of objects between between Web workers and the main thread. 
+    Mainly usable for transfer of big amount of data e.g. via ArrayBuffer. @see [Transferable](https://developer.mozilla.org/en-US/docs/Web/API/Transferable) 
 * `runUrl`: Basically the same as 
     * `url`:  The url you would use to create a [`Worker`](https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker) instance
     * `data`: Same as the `run` method

--- a/app/app.component.ts
+++ b/app/app.component.ts
@@ -40,6 +40,7 @@ import { Result } from './result';
             fib({{ result.number }}) = {{ result.result }}
         </p>
     </div>
+    <my-transfer-array></my-transfer-array>
   `,
     styles: [
         `
@@ -63,8 +64,7 @@ import { Result } from './result';
             }
         }
         `
-    ],
-    providers: [WebWorkerService]
+    ]
 })
 export class AppComponent implements OnInit {
     public webWorkerResults: any[] = [];

--- a/app/app.module.ts
+++ b/app/app.module.ts
@@ -1,12 +1,16 @@
-import { NgModule }      from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
-import { FormsModule }   from '@angular/forms';
+import {NgModule} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+import {FormsModule} from '@angular/forms';
 
-import { AppComponent }  from './app.component';
+import {AppComponent} from './app.component';
+import {TransferArrayComponent} from './transferArray.component';
+import {WebWorkerService} from '../web-worker.service';
 
 @NgModule({
-  imports:      [ BrowserModule, FormsModule ],
-  declarations: [ AppComponent ],
-  bootstrap:    [ AppComponent ]
+    imports: [BrowserModule, FormsModule],
+    declarations: [AppComponent, TransferArrayComponent],
+    providers: [WebWorkerService],
+    bootstrap: [AppComponent]
 })
-export class AppModule { }
+export class AppModule {
+}

--- a/app/result.ts
+++ b/app/result.ts
@@ -1,5 +1,4 @@
 export class Result {
     constructor(public number: number, public result: number, public loading: boolean) {
-        
     }
 }

--- a/app/transferArray.component.ts
+++ b/app/transferArray.component.ts
@@ -1,0 +1,100 @@
+import {Component} from '@angular/core';
+import {WebWorkerService} from '../web-worker.service';
+
+@Component({
+    selector: 'my-transfer-array',
+    template: `
+    <h2>Transfering big data array to web worker, fill it with random numbers and transfer it back</h2>
+    <form (ngSubmit)='startTransferArray()'>
+        <div>
+            <span>Array length filled with random numbers</span>
+            <input type='number' [(ngModel)]='arrayLength' name='array length' />
+            <span> Results in an ArrayBuffer of length: {{arrayLength * 8}}Bytes</span>
+        </div>
+        <button type='submit'>Transfer array to web worker</button>
+    </form>
+    <div *ngIf="transferTimeFromWorkerMs"> 
+        <h4>Transfer times with transferList</h4>
+        <span>
+        Transfer time to worker: {{transferTimeToWorkerMs}}
+        </span>
+        <br/>
+        <span>
+        Transfer time from worker: {{transferTimeFromWorkerMs}}ms.
+        </span>
+    </div>
+    <div *ngIf="transferTimeWithoutTransferListToWorkerMs">
+        <h4>Transfer times without transfer object</h4>
+        <span>
+        Transfer time to worker: {{transferTimeWithoutTransferListToWorkerMs}}ms.
+        </span>
+        <br/>
+        <span>
+        Transfer time from worker: {{transferTimeWithoutTransferListFromWorkerMs}}ms.
+        </span>
+    </div>
+    <div><h4>First 100 elements from array:</h4>
+        <div *ngFor="let elem of arrayToShow">{{elem}}</div>
+    </div>
+    `,
+})
+export class TransferArrayComponent {
+
+    public view: Float64Array;
+    public arrayLength: number = 30000000;
+    public transferTimeFromWorkerMs: number;
+    public transferTimeToWorkerMs: number;
+    public transferTimeWithoutTransferListFromWorkerMs: number;
+    public transferTimeWithoutTransferListToWorkerMs: number;
+    private arrayToShow: Float64Array;
+
+    constructor(private _webWorkerService: WebWorkerService) {
+    }
+
+
+    startTransferArray() {
+        const arrayBuffer = new ArrayBuffer(this.arrayLength * Float64Array.BYTES_PER_ELEMENT);
+        this.view = new Float64Array(arrayBuffer);
+        let startTransferTime = performance.now();
+        this._webWorkerService.run(this.fillArrayWithRandom, {
+            buff: this.view.buffer,
+            useTransferObject: true
+        }, [this.view.buffer])
+            .then(({buffer, receiveTime, sendBackTime}) => {
+                this.transferTimeFromWorkerMs = performance.now() - sendBackTime;
+                this.transferTimeToWorkerMs = receiveTime - startTransferTime;
+                this.view = new Float64Array(buffer);
+            })
+            .then(() => {
+                startTransferTime = performance.now();
+                return this._webWorkerService.run(
+                    this.fillArrayWithRandom,
+                    {buff: this.view.buffer, useTransferObject: false});
+            })
+            .then(({buffer, receiveTime, sendBackTime}) => {
+                this.transferTimeWithoutTransferListFromWorkerMs = performance.now() - sendBackTime;
+                this.transferTimeWithoutTransferListToWorkerMs = receiveTime - startTransferTime;
+                this.view = new Float64Array(buffer);
+            })
+            .then(() => {
+                this.arrayToShow = this.view.slice(0, Math.min(100, this.arrayLength));
+            });
+    }
+
+    fillArrayWithRandom(data: { buff: ArrayBuffer, useTransferObject: boolean }): {
+        data: { buffer: ArrayBuffer, receiveTime: number, sendBackTime: number },
+        transferList: any[]
+    } {
+        const receiveTime = performance.now();
+        const arrayToFill = new Float64Array(data.buff);
+        for (let i = 0; i < arrayToFill.length; i++) {
+            arrayToFill[i] = Math.random();
+        }
+        const sendBackTime = performance.now();
+        return {
+            data: {receiveTime, sendBackTime, buffer: arrayToFill.buffer},
+            transferList: data.useTransferObject ? [arrayToFill.buffer] : []
+        };
+    }
+}
+

--- a/dist/app/app.component.js
+++ b/dist/app/app.component.js
@@ -8,9 +8,9 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 var __metadata = (this && this.__metadata) || function (k, v) {
     if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
 };
-var core_1 = require("@angular/core");
-var web_worker_service_1 = require("../web-worker.service");
-var result_1 = require("./result");
+var core_1 = require('@angular/core');
+var web_worker_service_1 = require('../web-worker.service');
+var result_1 = require('./result');
 var AppComponent = (function () {
     function AppComponent(_webWorkerService) {
         this._webWorkerService = _webWorkerService;
@@ -88,18 +88,17 @@ var AppComponent = (function () {
         };
         return fib(n);
     };
+    AppComponent = __decorate([
+        core_1.Component({
+            selector: 'my-app',
+            template: "\n    <h2>calculating fibonacci using web worker</h2>\n    <form (ngSubmit)='startWebWorkerCalculation()'>\n        <div>\n            <span>calculate fib(n) from</span>\n            <input type='number' [(ngModel)]='webWorkerStart' name='webWorkerStart' />\n            <span>to:</span>\n            <input type='number' [(ngModel)]='webWorkerEnd' name='webWorkerEnd' />\n        </div>\n        <button type='submit'>Start</button>\n        <button type='button' (click)='stopWebWorkerCalculation()'>Stop</button>\n    </form>\n    <div>\n        <p *ngFor='let result of webWorkerResults'>\n            fib({{ result.number }}) = \n            <span *ngIf='result.loading' class='spin-me-baby'>... calculating ...</span>\n            <span *ngIf='!result.loading'>{{ result.result }}</span> \n        </p>\n    </div>\n    \n    <h2>calculating fibonacci using main UI thread</h2>\n    <form (ngSubmit)='startSynchronousCalculation()'>\n        <div>\n            <span>calculate fib(n) from</span>\n            <input type='number' [(ngModel)]='synchronousStart' name='synchronousStart' />\n            <span>to:</span>\n            <input type='number' [(ngModel)]='synchronousEnd' name='synchronousEnd' />\n        </div>\n        <button type='submit'>Start (might lock up your browser for large numbers)</button>\n    </form>\n    <div>\n        <span *ngIf='synchronousDuration' [class.zoom-me-baby]='true'>took {{ synchronousDuration }} seconds</span>\n        <p *ngFor='let result of synchronousResults'>\n            fib({{ result.number }}) = {{ result.result }}\n        </p>\n    </div>\n    <my-transfer-array></my-transfer-array>\n  ",
+            styles: [
+                "\n        .spin-me-baby {\n            animation: spin 4s linear infinite;\n        }\n        @keyframes spin { \n            100% {\n                transform: rotate(360deg);\n            }\n        }\n        .zoom-me-baby {\n            animation: zoom 4s linear infinite;\n        }\n        @keyframes zoom {\n            50% {\n                font-size: 2em;\n            }\n            100% {\n                font-size: 1em;\n            }\n        }\n        "
+            ]
+        }), 
+        __metadata('design:paramtypes', [web_worker_service_1.WebWorkerService])
+    ], AppComponent);
     return AppComponent;
 }());
-AppComponent = __decorate([
-    core_1.Component({
-        selector: 'my-app',
-        template: "\n    <h2>calculating fibonacci using web worker</h2>\n    <form (ngSubmit)='startWebWorkerCalculation()'>\n        <div>\n            <span>calculate fib(n) from</span>\n            <input type='number' [(ngModel)]='webWorkerStart' name='webWorkerStart' />\n            <span>to:</span>\n            <input type='number' [(ngModel)]='webWorkerEnd' name='webWorkerEnd' />\n        </div>\n        <button type='submit'>Start</button>\n        <button type='button' (click)='stopWebWorkerCalculation()'>Stop</button>\n    </form>\n    <div>\n        <p *ngFor='let result of webWorkerResults'>\n            fib({{ result.number }}) = \n            <span *ngIf='result.loading' class='spin-me-baby'>... calculating ...</span>\n            <span *ngIf='!result.loading'>{{ result.result }}</span> \n        </p>\n    </div>\n    \n    <h2>calculating fibonacci using main UI thread</h2>\n    <form (ngSubmit)='startSynchronousCalculation()'>\n        <div>\n            <span>calculate fib(n) from</span>\n            <input type='number' [(ngModel)]='synchronousStart' name='synchronousStart' />\n            <span>to:</span>\n            <input type='number' [(ngModel)]='synchronousEnd' name='synchronousEnd' />\n        </div>\n        <button type='submit'>Start (might lock up your browser for large numbers)</button>\n    </form>\n    <div>\n        <span *ngIf='synchronousDuration' [class.zoom-me-baby]='true'>took {{ synchronousDuration }} seconds</span>\n        <p *ngFor='let result of synchronousResults'>\n            fib({{ result.number }}) = {{ result.result }}\n        </p>\n    </div>\n  ",
-        styles: [
-            "\n        .spin-me-baby {\n            animation: spin 4s linear infinite;\n        }\n        @keyframes spin { \n            100% {\n                transform: rotate(360deg);\n            }\n        }\n        .zoom-me-baby {\n            animation: zoom 4s linear infinite;\n        }\n        @keyframes zoom {\n            50% {\n                font-size: 2em;\n            }\n            100% {\n                font-size: 1em;\n            }\n        }\n        "
-        ],
-        providers: [web_worker_service_1.WebWorkerService]
-    }),
-    __metadata("design:paramtypes", [web_worker_service_1.WebWorkerService])
-], AppComponent);
 exports.AppComponent = AppComponent;
 //# sourceMappingURL=app.component.js.map

--- a/dist/app/app.module.js
+++ b/dist/app/app.module.js
@@ -5,21 +5,28 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-var core_1 = require("@angular/core");
-var platform_browser_1 = require("@angular/platform-browser");
-var forms_1 = require("@angular/forms");
-var app_component_1 = require("./app.component");
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+var core_1 = require('@angular/core');
+var platform_browser_1 = require('@angular/platform-browser');
+var forms_1 = require('@angular/forms');
+var app_component_1 = require('./app.component');
+var transferArray_component_1 = require('./transferArray.component');
+var web_worker_service_1 = require('../web-worker.service');
 var AppModule = (function () {
     function AppModule() {
     }
+    AppModule = __decorate([
+        core_1.NgModule({
+            imports: [platform_browser_1.BrowserModule, forms_1.FormsModule],
+            declarations: [app_component_1.AppComponent, transferArray_component_1.TransferArrayComponent],
+            providers: [web_worker_service_1.WebWorkerService],
+            bootstrap: [app_component_1.AppComponent]
+        }), 
+        __metadata('design:paramtypes', [])
+    ], AppModule);
     return AppModule;
 }());
-AppModule = __decorate([
-    core_1.NgModule({
-        imports: [platform_browser_1.BrowserModule, forms_1.FormsModule],
-        declarations: [app_component_1.AppComponent],
-        bootstrap: [app_component_1.AppComponent]
-    })
-], AppModule);
 exports.AppModule = AppModule;
 //# sourceMappingURL=app.module.js.map

--- a/dist/app/main.js
+++ b/dist/app/main.js
@@ -1,5 +1,5 @@
 "use strict";
-var platform_browser_dynamic_1 = require("@angular/platform-browser-dynamic");
-var app_module_1 = require("./app.module");
+var platform_browser_dynamic_1 = require('@angular/platform-browser-dynamic');
+var app_module_1 = require('./app.module');
 platform_browser_dynamic_1.platformBrowserDynamic().bootstrapModule(app_module_1.AppModule);
 //# sourceMappingURL=main.js.map

--- a/dist/app/transferArray.component.js
+++ b/dist/app/transferArray.component.js
@@ -1,0 +1,69 @@
+"use strict";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+var core_1 = require('@angular/core');
+var web_worker_service_1 = require('../web-worker.service');
+var TransferArrayComponent = (function () {
+    function TransferArrayComponent(_webWorkerService) {
+        this._webWorkerService = _webWorkerService;
+        this.arrayLength = 30000000;
+    }
+    TransferArrayComponent.prototype.startTransferArray = function () {
+        var _this = this;
+        var arrayBuffer = new ArrayBuffer(this.arrayLength * Float64Array.BYTES_PER_ELEMENT);
+        this.view = new Float64Array(arrayBuffer);
+        var startTransferTime = performance.now();
+        this._webWorkerService.run(this.fillArrayWithRandom, {
+            buff: this.view.buffer,
+            useTransferObject: true
+        }, [this.view.buffer])
+            .then(function (_a) {
+            var buffer = _a.buffer, receiveTime = _a.receiveTime, sendBackTime = _a.sendBackTime;
+            _this.transferTimeFromWorkerMs = performance.now() - sendBackTime;
+            _this.transferTimeToWorkerMs = receiveTime - startTransferTime;
+            _this.view = new Float64Array(buffer);
+        })
+            .then(function () {
+            startTransferTime = performance.now();
+            return _this._webWorkerService.run(_this.fillArrayWithRandom, { buff: _this.view.buffer, useTransferObject: false });
+        })
+            .then(function (_a) {
+            var buffer = _a.buffer, receiveTime = _a.receiveTime, sendBackTime = _a.sendBackTime;
+            _this.transferTimeWithoutTransferListFromWorkerMs = performance.now() - sendBackTime;
+            _this.transferTimeWithoutTransferListToWorkerMs = receiveTime - startTransferTime;
+            _this.view = new Float64Array(buffer);
+        })
+            .then(function () {
+            _this.arrayToShow = _this.view.slice(0, Math.min(100, _this.arrayLength));
+        });
+    };
+    TransferArrayComponent.prototype.fillArrayWithRandom = function (data) {
+        var receiveTime = performance.now();
+        var arrayToFill = new Float64Array(data.buff);
+        for (var i = 0; i < arrayToFill.length; i++) {
+            arrayToFill[i] = Math.random();
+        }
+        var sendBackTime = performance.now();
+        return {
+            data: { receiveTime: receiveTime, sendBackTime: sendBackTime, buffer: arrayToFill.buffer },
+            transferList: data.useTransferObject ? [arrayToFill.buffer] : []
+        };
+    };
+    TransferArrayComponent = __decorate([
+        core_1.Component({
+            selector: 'my-transfer-array',
+            template: "\n    <h2>Transfering big data array to web worker, fill it with random numbers and transfer it back</h2>\n    <form (ngSubmit)='startTransferArray()'>\n        <div>\n            <span>Array length filled with random numbers</span>\n            <input type='number' [(ngModel)]='arrayLength' name='array length' />\n            <span> Results in an ArrayBuffer of length: {{arrayLength * 8}}Bytes</span>\n        </div>\n        <button type='submit'>Transfer array to web worker</button>\n    </form>\n    <div *ngIf=\"transferTimeFromWorkerMs\"> \n        <h4>Transfer times with transferList</h4>\n        <span>\n        Transfer time to worker: {{transferTimeToWorkerMs}}\n        </span>\n        <br/>\n        <span>\n        Transfer time from worker: {{transferTimeFromWorkerMs}}ms.\n        </span>\n    </div>\n    <div *ngIf=\"transferTimeWithoutTransferListToWorkerMs\">\n        <h4>Transfer times without transfer object</h4>\n        <span>\n        Transfer time to worker: {{transferTimeWithoutTransferListToWorkerMs}}ms.\n        </span>\n        <br/>\n        <span>\n        Transfer time from worker: {{transferTimeWithoutTransferListFromWorkerMs}}ms.\n        </span>\n    </div>\n    <div><h4>First 100 elements from array:</h4>\n        <div *ngFor=\"let elem of arrayToShow\">{{elem}}</div>\n    </div>\n    ",
+        }), 
+        __metadata('design:paramtypes', [web_worker_service_1.WebWorkerService])
+    ], TransferArrayComponent);
+    return TransferArrayComponent;
+}());
+exports.TransferArrayComponent = TransferArrayComponent;
+//# sourceMappingURL=transferArray.component.js.map

--- a/dist/web-worker.service.js
+++ b/dist/web-worker.service.js
@@ -10,17 +10,21 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-var core_1 = require("@angular/core");
-var web_worker_1 = require("./web-worker");
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+var core_1 = require('@angular/core');
+var web_worker_1 = require('./web-worker');
 var WebWorkerService = (function (_super) {
     __extends(WebWorkerService, _super);
     function WebWorkerService() {
-        return _super !== null && _super.apply(this, arguments) || this;
+        _super.apply(this, arguments);
     }
+    WebWorkerService = __decorate([
+        core_1.Injectable(), 
+        __metadata('design:paramtypes', [])
+    ], WebWorkerService);
     return WebWorkerService;
 }(web_worker_1.WebWorkerService));
-WebWorkerService = __decorate([
-    core_1.Injectable()
-], WebWorkerService);
 exports.WebWorkerService = WebWorkerService;
 //# sourceMappingURL=web-worker.service.js.map

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-web-worker",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "",
   "author": "Haochi Chen",
   "license": "ISC",

--- a/web-worker.interface.ts
+++ b/web-worker.interface.ts
@@ -1,6 +1,9 @@
 export interface IWebWorkerService {
-    run<T>(workerFunction: (input: any) => T, data?: any): Promise<T>;
-    runUrl(url: string, data?: any): Promise<any>;
+    run<T>(workerFunction: (input: any) => T | { data: T, transferList: any[] }, data?: any, transferList?: any[]): Promise<T>;
+
+    runUrl<T>(url: string, data: any, transferList?: any[]): Promise<T>;
+
     terminate<T>(promise: Promise<T>): Promise<T>;
+
     getWorker(promise: Promise<any>): Worker;
-} 
+}

--- a/web-worker.ts
+++ b/web-worker.ts
@@ -4,25 +4,25 @@ export class WebWorkerService implements IWebWorkerService {
     private workerFunctionToUrlMap = new WeakMap<Function, string>();
     private promiseToWorkerMap = new WeakMap<Promise<any>, Worker>();
 
-    run<T>(workerFunction: (input: any) => T, data?: any): Promise<T> {
+    run<T>(workerFunction: (input: any) => T | { data: T, transferList: any[] }, data?: any, transferList?: any[]): Promise<T> {
         const url = this.getOrCreateWorkerUrl(workerFunction);
-        return this.runUrl(url, data);
+        return this.runUrl(url, data, transferList);
     }
-    
-    runUrl(url: string, data?: any): Promise<any> {
+
+    runUrl<T>(url: string, data: any, transferList?: any[]): Promise<T> {
         const worker = new Worker(url);
-        const promise = this.createPromiseForWorker(worker, data);
+        const promise: Promise<T> = this.createPromiseForWorker<T>(worker, data, transferList);
         const promiseCleaner = this.createPromiseCleaner(promise);
-        
+
         this.promiseToWorkerMap.set(promise, worker);
 
         promise
             .then(promiseCleaner)
             .catch(promiseCleaner);
-            
+
         return promise;
     }
-    
+
     terminate<T>(promise: Promise<T>): Promise<T> {
         return this.removePromise(promise);
     }
@@ -30,15 +30,15 @@ export class WebWorkerService implements IWebWorkerService {
     getWorker(promise: Promise<any>): Worker {
         return this.promiseToWorkerMap.get(promise);
     }
-    
-    private createPromiseForWorker<T>(worker: Worker, data: any) {
+
+    private createPromiseForWorker<T>(worker: Worker, data: any, transferList?: any[]) {
         return new Promise<T>((resolve, reject) => {
             worker.addEventListener('message', (event) => resolve(event.data));
             worker.addEventListener('error', reject);
-            worker.postMessage(data);
+            worker.postMessage(data, transferList);
         });
     }
-    
+
     private getOrCreateWorkerUrl(fn: Function): string {
         if (!this.workerFunctionToUrlMap.has(fn)) {
             const url = this.createWorkerUrl(fn);
@@ -52,21 +52,25 @@ export class WebWorkerService implements IWebWorkerService {
         const resolveString = resolve.toString();
         const webWorkerTemplate = `
             self.addEventListener('message', function(e) {
-                postMessage((${resolveString})(e.data));
+                const result = (${resolveString})(e.data);
+                if(result.data && result.transferList){
+                    postMessage(result.data, result.transferList)
+                }    
+                postMessage(result);
             });
         `;
-        const blob = new Blob([webWorkerTemplate], { type: 'text/javascript' });
+        const blob = new Blob([webWorkerTemplate], {type: 'text/javascript'});
         return URL.createObjectURL(blob);
     }
-    
-    private createPromiseCleaner<T>(promise: Promise<T>) : (input: any) => T {
+
+    private createPromiseCleaner<T>(promise: Promise<T>): (input: any) => T {
         return (event) => {
             this.removePromise(promise);
-            return event;  
+            return event;
         };
     }
-    
-    private removePromise<T>(promise: Promise<T>) : Promise<T> {
+
+    private removePromise<T>(promise: Promise<T>): Promise<T> {
         const worker = this.promiseToWorkerMap.get(promise);
         if (worker) {
             worker.terminate();


### PR DESCRIPTION
Added the optional parameter  `transferList` to the WebWorkerService `use` function. If provided, the parameter is set as the transferList parameter of the postMessage method. 
It is used to give control over an e.g. ArrayBuffer to the execution context of the webworker without cloning the hole data.

Also the webworker can now provide a transferList inside the return object. 

This can be usefull for task like image manipulation and everything that needs to transfer a big amount of data.

Also I implemented an example showing the times used for big data transfer with and without transferList. 

Also I raised the version number to 0.0.7