### PR TITLE
Angular 5 Support

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,1 @@
+export * from './web-worker.service';

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "angular2-web-worker",
-  "version": "0.0.5",
+  "name": "angular5-web-worker",
+  "version": "0.0.7",
   "description": "",
   "author": "Haochi Chen",
   "license": "ISC",
   "keywords": [
     "angular",
-    "angular 2",
+    "angular 5",
     "web",
     "worker"
   ],
@@ -21,40 +21,40 @@
     "tsc:w": "tsc -w"
   },
   "peerDependencies": {
-    "@angular/common": "~2.4.0",
-    "@angular/compiler": "~2.4.0",
-    "@angular/core": "~2.4.0",
-    "@angular/forms": "~2.4.0",
-    "@angular/http": "~2.4.0",
-    "@angular/platform-browser": "~2.4.0",
-    "@angular/platform-browser-dynamic": "~2.4.0",
-    "@angular/router": "~3.4.0",
+    "@angular/common": "~5.1.2",
+    "@angular/compiler": "~5.1.2",
+    "@angular/core": "~5.1.2",
+    "@angular/forms": "~5.1.2",
+    "@angular/http": "~5.1.2",
+    "@angular/platform-browser": "~5.1.2",
+    "@angular/platform-browser-dynamic": "~5.1.2",
+    "@angular/router": "~5.1.2",
 
-    "angular-in-memory-web-api": "~0.2.4",
-    "systemjs": "0.19.40",
-    "core-js": "^2.4.1",
-    "rxjs": "5.0.1",
-    "zone.js": "^0.7.4"
+    "angular-in-memory-web-api": "~0.5.3",
+    "systemjs": "0.20.19",
+    "core-js": "^2.5.3",
+    "rxjs": "5.5.6",
+    "zone.js": "^0.8.18"
   },
   "devDependencies": {
-    "concurrently": "^3.1.0",
-    "lite-server": "^2.2.2",
-    "typescript": "~2.0.10",
+    "concurrently": "^3.5.1",
+    "lite-server": "^2.3.0",
+    "typescript": "~2.4.2",
 
     "canonical-path": "0.0.2",
-    "http-server": "^0.9.0",
-    "tslint": "^3.15.1",
-    "lodash": "^4.16.4",
-    "jasmine-core": "~2.4.1",
-    "karma": "^1.3.0",
-    "karma-chrome-launcher": "^2.0.0",
+    "http-server": "^0.10.0",
+    "tslint": "~5.7.0",
+    "lodash": "^4.17.4",
+    "jasmine-core": "~2.8.0",
+    "karma": "^2.0.0",
+    "karma-chrome-launcher": "^2.2.0",
     "karma-cli": "^1.0.1",
-    "karma-jasmine": "^1.0.2",
+    "karma-jasmine": "^1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
-    "protractor": "~4.0.14",
-    "rimraf": "^2.5.4",
+    "protractor": "~5.2.2",
+    "rimraf": "^2.6.2",
 
-    "@types/node": "^6.0.46",
-    "@types/jasmine": "^2.5.36"
+    "@types/node": "^8.5.2",
+    "@types/jasmine": "^2.8.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,11 @@
       "es2017",
       "dom"
     ]
-  }
+  },
+  "files": [
+    "index.ts"
+  ],
+  "include": [
+    "index.ts"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,21 @@
 {
+  "compileOnSave": false,
   "compilerOptions": {
-    "target": "es5",
-    "module": "commonjs",
-    "moduleResolution": "node",
     "outDir": "dist",
     "sourceMap": true,
+    "declaration": false,
+    "moduleResolution": "node",
+    "noImplicitAny": true, 
+    "suppressImplicitAnyIndexErrors": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "lib": [ "es2015", "dom" ],
-    "noImplicitAny": true,
-    "suppressImplicitAnyIndexErrors": true
+    "target": "es5",
+    "typeRoots": [
+      "node_modules/@types"
+    ],
+    "lib": [
+      "es2017",
+      "dom"
+    ]
   }
 }

--- a/web-worker.interface.ts
+++ b/web-worker.interface.ts
@@ -1,6 +1,6 @@
 export interface IWebWorkerService {
-    run<T>(workerFunction: (input: any) => T, data?: any): Promise<T>;
-    runUrl(url: string, data?: any): Promise<any>;
-    terminate<T>(promise: Promise<T>): Promise<T>;
-    getWorker(promise: Promise<any>): Worker;
-} 
+    run<T>      (workerFunction: (input: any) => T, data?: any): Promise<T>;
+    runUrl      (url: string, data?: any):                       Promise<any>;
+    terminate<T>(promise: Promise<T>):                           Promise<T>;
+    getWorker   (promise: Promise<any>):                         Worker;
+}

--- a/web-worker.service.ts
+++ b/web-worker.service.ts
@@ -1,5 +1,6 @@
-import {Injectable} from '@angular/core';
-import {WebWorkerService as WebWorker } from './web-worker';
+import { Injectable } from '@angular/core';
+
+import { WebWorker }  from './web-worker';
 
 @Injectable()
 export class WebWorkerService extends WebWorker {

--- a/web-worker.ts
+++ b/web-worker.ts
@@ -1,36 +1,38 @@
-import {IWebWorkerService} from './web-worker.interface';
+import { IWebWorkerService } from './web-worker.interface';
 
-export class WebWorkerService implements IWebWorkerService {
-    private workerFunctionToUrlMap = new WeakMap<Function, string>();
-    private promiseToWorkerMap = new WeakMap<Promise<any>, Worker>();
+export class WebWorker implements IWebWorkerService {
+    private promiseToWorkerMap:     WeakMap<Promise<any>, Worker>;
+    private workerFunctionToUrlMap: WeakMap<Function, string>;
 
-    run<T>(workerFunction: (input: any) => T, data?: any): Promise<T> {
-        const url = this.getOrCreateWorkerUrl(workerFunction);
+    constructor() {
+        this.promiseToWorkerMap     = new WeakMap<Promise<any>, Worker>();
+        this.workerFunctionToUrlMap = new WeakMap<Function, string>();
+    }
+
+    public run<T>(workerFunction: (input: any) => T, data?: any): Promise<T> {
+        const url: string = this.getOrCreateWorkerUrl(workerFunction);
         return this.runUrl(url, data);
     }
-    
-    runUrl(url: string, data?: any): Promise<any> {
-        const worker = new Worker(url);
-        const promise = this.createPromiseForWorker(worker, data);
+
+    public runUrl(url: string, data?: any): Promise<any> {
+        const worker         = new Worker(url);
+        const promise        = this.createPromiseForWorker(worker, data);
         const promiseCleaner = this.createPromiseCleaner(promise);
-        
+
         this.promiseToWorkerMap.set(promise, worker);
 
-        promise
-            .then(promiseCleaner)
-            .catch(promiseCleaner);
-            
-        return promise;
+        return promise.then(promiseCleaner)
+                      .catch(promiseCleaner);
     }
-    
-    terminate<T>(promise: Promise<T>): Promise<T> {
+
+    public terminate<T>(promise: Promise<T>): Promise<T> {
         return this.removePromise(promise);
     }
 
-    getWorker(promise: Promise<any>): Worker {
+    public getWorker(promise: Promise<any>): Worker {
         return this.promiseToWorkerMap.get(promise);
     }
-    
+
     private createPromiseForWorker<T>(worker: Worker, data: any) {
         return new Promise<T>((resolve, reject) => {
             worker.addEventListener('message', (event) => resolve(event.data));
@@ -38,7 +40,7 @@ export class WebWorkerService implements IWebWorkerService {
             worker.postMessage(data);
         });
     }
-    
+
     private getOrCreateWorkerUrl(fn: Function): string {
         if (!this.workerFunctionToUrlMap.has(fn)) {
             const url = this.createWorkerUrl(fn);
@@ -49,28 +51,30 @@ export class WebWorkerService implements IWebWorkerService {
     }
 
     private createWorkerUrl(resolve: Function): string {
-        const resolveString = resolve.toString();
+        const resolveString     = resolve.toString();
         const webWorkerTemplate = `
             self.addEventListener('message', function(e) {
                 postMessage((${resolveString})(e.data));
             });
         `;
         const blob = new Blob([webWorkerTemplate], { type: 'text/javascript' });
+
         return URL.createObjectURL(blob);
     }
-    
-    private createPromiseCleaner<T>(promise: Promise<T>) : (input: any) => T {
+
+    private createPromiseCleaner<T>(promise: Promise<T>): (input: any) => T {
         return (event) => {
             this.removePromise(promise);
-            return event;  
+            return event;
         };
     }
-    
-    private removePromise<T>(promise: Promise<T>) : Promise<T> {
+
+    private removePromise<T>(promise: Promise<T>): Promise<T> {
         const worker = this.promiseToWorkerMap.get(promise);
         if (worker) {
             worker.terminate();
         }
+
         this.promiseToWorkerMap.delete(promise);
         return promise;
     }


### PR DESCRIPTION
+ Changed name to be `angular5-web-worker`
+ Bumped version to `0.0.7`
+ Updated project dependencies so now when you install this plugin, you no longer see the following warning:   
![image](https://user-images.githubusercontent.com/25469424/34315608-04f638ba-e737-11e7-8479-aa20e33e406b.png)
+ Fixed all tslint errors
+ Updated `tsconfig.json` to latest @angular/cli format
+ Added `index.ts` to export `web-worker.service` for easy import from project like so:
```import { WebWorkerService } from 'angular5-web-worker';```